### PR TITLE
Bug fix/toggle habit completion

### DIFF
--- a/api/database/factories/HabitFactory.php
+++ b/api/database/factories/HabitFactory.php
@@ -23,7 +23,6 @@ class HabitFactory extends Factory
                 new HabitFrequency('weekly', [1, 2, 3]),
             ]),
             'last_completed' => $this->faker->dateTime(),
-            'last_incompleted' => $this->faker->dateTime(),
         ];
     }
 }

--- a/api/database/migrations/2021_09_26_123835_create_habits_table.php
+++ b/api/database/migrations/2021_09_26_123835_create_habits_table.php
@@ -15,9 +15,7 @@ class CreateHabitsTable extends Migration
             $table->string('streak');
             $table->json('frequency');
             $table->datetime('last_completed')->nullable();
-            $table->datetime('last_incompleted')->nullable();
             $table->boolean('stopped')->default(false);
-            $table->timestamps();
         });
     }
 

--- a/api/src/HabitTracking/Application/HabitService.php
+++ b/api/src/HabitTracking/Application/HabitService.php
@@ -3,7 +3,7 @@
 namespace HabitTracking\Application;
 
 use HabitTracking\Domain\Contracts\HabitRepository;
-use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthorException;
+use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthor;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitFrequency;
 use HabitTracking\Domain\HabitId;
@@ -33,7 +33,7 @@ class HabitService
         $habit = $this->repository->find(HabitId::fromString($id));
 
         if ($habit->authorId() !== $authorId) {
-            throw new HabitDoesNotBelongToAuthorException();
+            throw new HabitDoesNotBelongToAuthor();
         }
 
         return $habit;
@@ -65,7 +65,7 @@ class HabitService
         $habit = $this->repository->find(HabitId::fromString($id));
 
         if ($habit->authorId() !== $authorId) {
-            throw new HabitDoesNotBelongToAuthorException();
+            throw new HabitDoesNotBelongToAuthor();
         }
 
         $habit->markAsComplete();
@@ -83,7 +83,7 @@ class HabitService
         $habit = $this->repository->find(HabitId::fromString($id));
 
         if ($habit->authorId() !== $authorId) {
-            throw new HabitDoesNotBelongToAuthorException();
+            throw new HabitDoesNotBelongToAuthor();
         }
 
         $habit->markAsIncomplete();
@@ -103,7 +103,7 @@ class HabitService
         $habit = $this->repository->find(HabitId::fromString($id));
 
         if ($habit->authorId() !== $authorId) {
-            throw new HabitDoesNotBelongToAuthorException();
+            throw new HabitDoesNotBelongToAuthor();
         }
 
         $habit->edit($name, new HabitFrequency(...$frequency));
@@ -121,7 +121,7 @@ class HabitService
         $habit = $this->repository->find(HabitId::fromString($id));
 
         if ($habit->authorId() !== $authorId) {
-            throw new HabitDoesNotBelongToAuthorException();
+            throw new HabitDoesNotBelongToAuthor();
         }
 
         $habit->stop();

--- a/api/src/HabitTracking/Domain/Contracts/HabitRepository.php
+++ b/api/src/HabitTracking/Domain/Contracts/HabitRepository.php
@@ -2,7 +2,7 @@
 
 namespace HabitTracking\Domain\Contracts;
 
-use HabitTracking\Domain\Exceptions\HabitNotFoundException;
+use HabitTracking\Domain\Exceptions\HabitNotFound;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitId;
 use Illuminate\Support\Collection;
@@ -18,10 +18,10 @@ interface HabitRepository
 
     /**
      * @param HabitId $id
-     * @return Habit|null
-     * @throws HabitNotFoundException
+     * @return ?Habit
+     * @throws HabitNotFound
      */
-    public function find(HabitId $id) : ?Habit;
+    public function find(HabitId $id) : ? Habit;
 
     public function save(Habit $habit) : void;
 }

--- a/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyCompleted.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyCompleted.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HabitTracking\Domain\Exceptions;
+
+class HabitAlreadyCompleted extends \Exception
+{
+}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyCompletedException.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyCompletedException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace HabitTracking\Domain\Exceptions;
-
-class HabitAlreadyCompletedException extends \Exception
-{
-}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyIncompleted.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyIncompleted.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HabitTracking\Domain\Exceptions;
+
+class HabitAlreadyIncompleted extends \Exception
+{
+}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyIncompletedException.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyIncompletedException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace HabitTracking\Domain\Exceptions;
-
-class HabitAlreadyIncompletedException extends \Exception
-{
-}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyStopped.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitAlreadyStopped.php
@@ -2,7 +2,7 @@
 
 namespace HabitTracking\Domain\Exceptions;
 
-class HabitStoppedException extends \Exception
+class HabitAlreadyStopped extends \Exception
 {
     public function __construct()
     {

--- a/api/src/HabitTracking/Domain/Exceptions/HabitDoesNotBelongToAuthor.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitDoesNotBelongToAuthor.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace HabitTracking\Domain\Exceptions;
+
+class HabitDoesNotBelongToAuthor extends \Exception
+{
+}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitDoesNotBelongToAuthorException.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitDoesNotBelongToAuthorException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace HabitTracking\Domain\Exceptions;
-
-class HabitDoesNotBelongToAuthorException extends \Exception
-{
-}

--- a/api/src/HabitTracking/Domain/Exceptions/HabitNotFound.php
+++ b/api/src/HabitTracking/Domain/Exceptions/HabitNotFound.php
@@ -4,7 +4,7 @@ namespace HabitTracking\Domain\Exceptions;
 
 use HabitTracking\Domain\HabitId;
 
-class HabitNotFoundException extends \Exception
+class HabitNotFound extends \Exception
 {
     public function __construct(HabitId $id)
     {

--- a/api/src/HabitTracking/Domain/Habit.php
+++ b/api/src/HabitTracking/Domain/Habit.php
@@ -3,9 +3,9 @@
 namespace HabitTracking\Domain;
 
 use Carbon\CarbonImmutable;
-use HabitTracking\Domain\Exceptions\HabitAlreadyCompletedException;
-use HabitTracking\Domain\Exceptions\HabitAlreadyIncompletedException;
-use HabitTracking\Domain\Exceptions\HabitStoppedException;
+use HabitTracking\Domain\Exceptions\HabitAlreadyCompleted;
+use HabitTracking\Domain\Exceptions\HabitAlreadyIncompleted;
+use HabitTracking\Domain\Exceptions\HabitAlreadyStopped;
 
 class Habit implements \JsonSerializable
 {
@@ -35,7 +35,7 @@ class Habit implements \JsonSerializable
     public function markAsComplete() : void
     {
         if ($this->completed()) {
-            throw new HabitAlreadyCompletedException();
+            throw new HabitAlreadyCompleted();
         }
 
         $this->streak = $this->streak()->increment();
@@ -45,7 +45,7 @@ class Habit implements \JsonSerializable
     public function markAsIncomplete() : void
     {
         if ( ! $this->completed()) {
-            throw new HabitAlreadyIncompletedException();
+            throw new HabitAlreadyIncompleted();
         }
 
         $this->streak = $this->streak()->decrement();
@@ -64,7 +64,7 @@ class Habit implements \JsonSerializable
     public function stop() : void
     {
         if ($this->stopped()) {
-            throw new HabitStoppedException();
+            throw new HabitAlreadyStopped();
         }
 
         $this->stopped = true;

--- a/api/src/HabitTracking/Domain/Habit.php
+++ b/api/src/HabitTracking/Domain/Habit.php
@@ -14,12 +14,11 @@ class Habit implements \JsonSerializable
         private int $authorId,
         private string $name,
         private HabitFrequency $frequency,
-        private ?HabitStreak $streak = null,
+        private ? HabitStreak $streak = null,
         private bool $stopped = false,
-        private ?CarbonImmutable $lastCompleted = null,
-        private ?CarbonImmutable $lastIncompleted = null,
+        private ? CarbonImmutable $lastCompleted = null,
+        private ? CarbonImmutable $lastIncompleted = null,
     ) {
-
         $this->streak = $streak ?? new HabitStreak();
     }
 
@@ -39,8 +38,8 @@ class Habit implements \JsonSerializable
             throw new HabitAlreadyCompletedException();
         }
 
-        $this->lastCompleted = new CarbonImmutable();
-        $this->streak()->increment();
+        $this->streak = $this->streak()->increment();
+        $this->lastCompleted = CarbonImmutable::now();
     }
 
     public function markAsIncomplete() : void
@@ -49,8 +48,8 @@ class Habit implements \JsonSerializable
             throw new HabitAlreadyIncompletedException();
         }
 
-        $this->lastIncompleted = new CarbonImmutable();
-        $this->streak()->decrement();
+        $this->streak = $this->streak()->decrement();
+        $this->lastIncompleted = CarbonImmutable::now();
     }
 
     public function edit(
@@ -96,12 +95,12 @@ class Habit implements \JsonSerializable
         return $this->streak;
     }
 
-    public function lastIncompleted() : ?CarbonImmutable
+    public function lastIncompleted() : ? CarbonImmutable
     {
         return $this->lastIncompleted;
     }
 
-    public function lastCompleted() : ?CarbonImmutable
+    public function lastCompleted() : ? CarbonImmutable
     {
         return $this->lastCompleted;
     }

--- a/api/src/HabitTracking/Domain/Habit.php
+++ b/api/src/HabitTracking/Domain/Habit.php
@@ -17,7 +17,6 @@ class Habit implements \JsonSerializable
         private ? HabitStreak $streak = null,
         private bool $stopped = false,
         private ? CarbonImmutable $lastCompleted = null,
-        private ? CarbonImmutable $lastIncompleted = null,
     ) {
         $this->streak = $streak ?? new HabitStreak();
     }
@@ -49,7 +48,7 @@ class Habit implements \JsonSerializable
         }
 
         $this->streak = $this->streak()->decrement();
-        $this->lastIncompleted = CarbonImmutable::now();
+        $this->lastCompleted = null;
     }
 
     public function edit(
@@ -95,11 +94,6 @@ class Habit implements \JsonSerializable
         return $this->streak;
     }
 
-    public function lastIncompleted() : ? CarbonImmutable
-    {
-        return $this->lastIncompleted;
-    }
-
     public function lastCompleted() : ? CarbonImmutable
     {
         return $this->lastCompleted;
@@ -107,17 +101,7 @@ class Habit implements \JsonSerializable
 
     public function completed() : bool
     {
-        if ( ! $this->lastCompleted()) {
-            return false;
-        }
-
-        if ( ! $this->lastIncompleted()) {
-            return $this->lastCompleted()->isToday();
-        }
-
-        return
-            $this->lastCompleted()->isToday() &&
-            $this->lastCompleted()->gt($this->lastIncompleted());
+        return null !== $this->lastCompleted();
     }
 
     public function stopped() : bool

--- a/api/src/HabitTracking/Domain/HabitFrequency.php
+++ b/api/src/HabitTracking/Domain/HabitFrequency.php
@@ -15,11 +15,11 @@ class HabitFrequency implements \JsonSerializable
     public const SATURDAY = CarbonImmutable::SATURDAY;
 
     private string $type;
-    private ?array $days;
+    private ? array $days;
 
     public function __construct(
         string $type,
-        ?array $days = null
+        ? array $days = null
     ) {
 
         if (( ! in_array($type, ['daily', 'weekly'])) ||
@@ -37,7 +37,7 @@ class HabitFrequency implements \JsonSerializable
         return $this->type;
     }
 
-    public function days() : ?array
+    public function days() : ? array
     {
         return $this->days;
     }

--- a/api/src/HabitTracking/Infrastructure/Eloquent/Habit.php
+++ b/api/src/HabitTracking/Infrastructure/Eloquent/Habit.php
@@ -23,6 +23,8 @@ class Habit extends Model
 
     public $incrementing = false;
 
+    public $timestamps = false;
+
     protected $fillable = [
         'id',
         'author_id',
@@ -37,7 +39,6 @@ class Habit extends Model
     protected $casts = [
         'frequency' => 'object',
         'last_completed' => 'date',
-        'last_incompleted' => 'date',
         'stopped' => 'boolean',
     ];
 
@@ -51,7 +52,6 @@ class Habit extends Model
             HabitStreak::fromString($this->streak),
             $this->stopped,
             $this->last_completed,
-            $this->last_incompleted,
         );
     }
 

--- a/api/src/HabitTracking/Infrastructure/Eloquent/HabitRepository.php
+++ b/api/src/HabitTracking/Infrastructure/Eloquent/HabitRepository.php
@@ -3,7 +3,7 @@
 namespace HabitTracking\Infrastructure\Eloquent;
 
 use HabitTracking\Domain\Contracts\HabitRepository as HabitRepositoryInterface;
-use HabitTracking\Domain\Exceptions\HabitNotFoundException;
+use HabitTracking\Domain\Exceptions\HabitNotFound;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitId;
 use HabitTracking\Infrastructure\Eloquent\Habit as EloquentHabit;
@@ -36,7 +36,7 @@ class HabitRepository implements HabitRepositoryInterface
         $habit = EloquentHabit::find($id);
 
         if ( ! $habit) {
-            throw new HabitNotFoundException($id);
+            throw new HabitNotFound($id);
         }
 
         return $habit->toModel();

--- a/api/src/HabitTracking/Infrastructure/Eloquent/HabitRepository.php
+++ b/api/src/HabitTracking/Infrastructure/Eloquent/HabitRepository.php
@@ -18,9 +18,7 @@ class HabitRepository implements HabitRepositoryInterface
 
         $query = EloquentHabit::where('author_id', $authorId);
 
-        if (array_key_exists('forToday', $filters) &&
-            $filters['forToday']
-        ) {
+        if ($filters['forToday'] ?? false) {
             $query->where(function ($query) {
                 $query
                     ->whereJsonContains('frequency->days', [now()->dayOfWeek])
@@ -31,7 +29,7 @@ class HabitRepository implements HabitRepositoryInterface
         return $query->get()->map->toModel();
     }
 
-    public function find(HabitId $id) : ?Habit
+    public function find(HabitId $id) : ? Habit
     {
         $habit = EloquentHabit::find($id);
 
@@ -52,7 +50,6 @@ class HabitRepository implements HabitRepositoryInterface
             'streak' => $habit->streak(),
             'frequency' => $habit->frequency(),
             'last_completed' => $habit->lastCompleted(),
-            'last_incompleted' => $habit->lastIncompleted(),
             'stopped' => $habit->stopped(),
         ]);
     }

--- a/api/src/HabitTracking/Infrastructure/HabitController.php
+++ b/api/src/HabitTracking/Infrastructure/HabitController.php
@@ -92,7 +92,8 @@ class HabitController extends Controller
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
         } catch (HabitDoesNotBelongToAuthor $e) {
-            return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
+            // return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
+            return response()->json($this->service->retrieveHabit($id, $this->auth->id()));
 
         } catch (HabitAlreadyCompleted $e) {
             return response()->json(null, JsonResponse::HTTP_BAD_REQUEST);
@@ -110,10 +111,11 @@ class HabitController extends Controller
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
         } catch (HabitDoesNotBelongToAuthor $e) {
-            return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
+            // return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
+            return response()->json($this->service->retrieveHabit($id, $this->auth->id()));
 
         } catch (HabitAlreadyIncompleted $e) {
-            return response()->json(null, JsonResponse::HTTP_BAD_REQUEST);
+            return response()->json($e::class, JsonResponse::HTTP_BAD_REQUEST);
         }
 
         return response()->json($habit);

--- a/api/src/HabitTracking/Infrastructure/HabitController.php
+++ b/api/src/HabitTracking/Infrastructure/HabitController.php
@@ -4,11 +4,11 @@ namespace HabitTracking\Infrastructure;
 
 use App\Http\Controllers\Controller;
 use HabitTracking\Application\HabitService;
-use HabitTracking\Domain\Exceptions\HabitAlreadyCompletedException;
-use HabitTracking\Domain\Exceptions\HabitAlreadyIncompletedException;
-use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthorException;
-use HabitTracking\Domain\Exceptions\HabitNotFoundException;
-use HabitTracking\Domain\Exceptions\HabitStoppedException;
+use HabitTracking\Domain\Exceptions\HabitAlreadyCompleted;
+use HabitTracking\Domain\Exceptions\HabitAlreadyIncompleted;
+use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthor;
+use HabitTracking\Domain\Exceptions\HabitNotFound;
+use HabitTracking\Domain\Exceptions\HabitAlreadyStopped;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -51,10 +51,10 @@ class HabitController extends Controller
         try {
             $habit = $this->service->retrieveHabit($id, $this->auth->id());
 
-        } catch (HabitNotFoundException $e) {
+        } catch (HabitNotFound $e) {
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
-        } catch (HabitDoesNotBelongToAuthorException $e) {
+        } catch (HabitDoesNotBelongToAuthor $e) {
             return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
         }
 
@@ -73,10 +73,10 @@ class HabitController extends Controller
                 $request->get('frequency'),
                 $this->auth->id()
             );
-        } catch (HabitNotFoundException $e) {
+        } catch (HabitNotFound $e) {
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
-        } catch (HabitDoesNotBelongToAuthorException $e) {
+        } catch (HabitDoesNotBelongToAuthor $e) {
             return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
         }
 
@@ -88,13 +88,13 @@ class HabitController extends Controller
         try {
             $habit = $this->service->markHabitAsComplete($id, $this->auth->id());
 
-        } catch (HabitNotFoundException $e) {
+        } catch (HabitNotFound $e) {
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
-        } catch (HabitDoesNotBelongToAuthorException $e) {
+        } catch (HabitDoesNotBelongToAuthor $e) {
             return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
 
-        } catch (HabitAlreadyCompletedException $e) {
+        } catch (HabitAlreadyCompleted $e) {
             return response()->json(null, JsonResponse::HTTP_BAD_REQUEST);
         }
 
@@ -106,13 +106,13 @@ class HabitController extends Controller
         try {
             $habit = $this->service->markHabitAsIncomplete($id, $this->auth->id());
 
-        } catch (HabitNotFoundException $e) {
+        } catch (HabitNotFound $e) {
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
-        } catch (HabitDoesNotBelongToAuthorException $e) {
+        } catch (HabitDoesNotBelongToAuthor $e) {
             return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
 
-        } catch (HabitAlreadyIncompletedException $e) {
+        } catch (HabitAlreadyIncompleted $e) {
             return response()->json(null, JsonResponse::HTTP_BAD_REQUEST);
         }
 
@@ -124,13 +124,13 @@ class HabitController extends Controller
         try {
             $this->service->stopHabit($id, $this->auth->id());
 
-        } catch (HabitNotFoundException $e) {
+        } catch (HabitNotFound $e) {
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
-        } catch (HabitDoesNotBelongToAuthorException $e) {
+        } catch (HabitDoesNotBelongToAuthor $e) {
             return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
 
-        } catch (HabitStoppedException $e) {
+        } catch (HabitAlreadyStopped $e) {
             return response()->json(
                 ['error' => ['message' => $e->getMessage()]],
                 JsonResponse::HTTP_BAD_REQUEST

--- a/api/src/HabitTracking/Infrastructure/HabitController.php
+++ b/api/src/HabitTracking/Infrastructure/HabitController.php
@@ -92,8 +92,7 @@ class HabitController extends Controller
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
         } catch (HabitDoesNotBelongToAuthor $e) {
-            // return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
-            return response()->json($this->service->retrieveHabit($id, $this->auth->id()));
+            return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
 
         } catch (HabitAlreadyCompleted $e) {
             return response()->json(null, JsonResponse::HTTP_BAD_REQUEST);
@@ -111,8 +110,7 @@ class HabitController extends Controller
             return response()->json(null, JsonResponse::HTTP_NOT_FOUND);
 
         } catch (HabitDoesNotBelongToAuthor $e) {
-            // return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
-            return response()->json($this->service->retrieveHabit($id, $this->auth->id()));
+            return response()->json(null, JsonResponse::HTTP_UNAUTHORIZED);
 
         } catch (HabitAlreadyIncompleted $e) {
             return response()->json($e::class, JsonResponse::HTTP_BAD_REQUEST);

--- a/api/tests/Integration/EloquentHabitRepositoryTest.php
+++ b/api/tests/Integration/EloquentHabitRepositoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use App\Models\User;
-use HabitTracking\Domain\Exceptions\HabitNotFoundException;
+use HabitTracking\Domain\Exceptions\HabitNotFound;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitId;
 use HabitTracking\Infrastructure\Eloquent\Habit as EloquentHabit;
@@ -87,7 +87,7 @@ it('throws a not found exception when finding non existent habit', function () {
     $id = HabitId::generate();
 
     expect(fn () => resolve(EloquentHabitRepository::class)->find($id))
-        ->toThrow(HabitNotFoundException::class, $id->toString());
+        ->toThrow(HabitNotFound::class, $id->toString());
 });
 
 it('persists a habit', function () {

--- a/api/tests/Integration/EloquentHabitRepositoryTest.php
+++ b/api/tests/Integration/EloquentHabitRepositoryTest.php
@@ -18,11 +18,9 @@ it('retrieves all habits by its author', function () {
 
     expect($results)
         ->toHaveCount(10)
-        ->each(
-            fn ($r) => $r
+        ->each(fn ($r) => $r
             ->toBeInstanceOf(Habit::class)
-            ->id()->toString()->toBeIn($habits->pluck('id'))
-        );
+            ->id()->toString()->toBeIn($habits->pluck('id')));
 });
 
 it('retrieves all habits for today by its author', function () {
@@ -46,12 +44,10 @@ it('retrieves all habits for today by its author', function () {
 
     expect($results)
         ->toHaveCount(5)
-        ->each(
-            fn ($r) => $r
+        ->each(fn ($r) => $r
             ->toBeInstanceOf(Habit::class)
             ->id()->toString()->toBeIn($todays->pluck('id'))
-            ->id()->toString()->not->toBeIn($tomorrows->pluck('id'))
-        );
+            ->id()->toString()->not->toBeIn($tomorrows->pluck('id')));
 });
 
 it("does not retrieve another author's habits", function () {
@@ -62,12 +58,10 @@ it("does not retrieve another author's habits", function () {
 
     expect($results)
         ->toHaveCount(10)
-        ->each(
-            fn ($r) => $r
+        ->each(fn ($r) => $r
             ->toBeInstanceOf(Habit::class)
             ->id()->toString()->toBeIn($mine->pluck('id'))
-            ->id()->toString()->not->toBeIn($notMine->pluck('id'))
-        );
+            ->id()->toString()->not->toBeIn($notMine->pluck('id')));
 });
 
 it('finds a habit', function () {
@@ -102,7 +96,6 @@ it('persists a habit', function () {
         'streak' => $habit->streak()->toString(),
         'frequency->type' => $habit->frequency()->type(),
         'last_completed' => null,
-        'last_incompleted' => null,
         'stopped' => $habit->stopped(),
     ]);
     $this->assertEquals(

--- a/api/tests/Integration/HabitServiceTest.php
+++ b/api/tests/Integration/HabitServiceTest.php
@@ -3,8 +3,8 @@
 use App\Models\User;
 use HabitTracking\Application\HabitService;
 use HabitTracking\Domain\Contracts\HabitRepository;
-use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthorException;
-use HabitTracking\Domain\Exceptions\HabitNotFoundException;
+use HabitTracking\Domain\Exceptions\HabitDoesNotBelongToAuthor;
+use HabitTracking\Domain\Exceptions\HabitNotFound;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitFrequency;
 use HabitTracking\Domain\HabitId;
@@ -189,7 +189,7 @@ it("cannot manage another user's habit", function () {
     ]);
 
     $actions->each(
-        fn ($action) => expect($action)->toThrow(HabitDoesNotBelongToAuthorException::class)
+        fn ($action) => expect($action)->toThrow(HabitDoesNotBelongToAuthor::class)
     );
 });
 
@@ -227,13 +227,13 @@ class CollectionHabitRepository implements HabitRepository
     /**
      * @param HabitId $id
      * @return Habit|null
-     * @throws HabitNotFoundException
+     * @throws HabitNotFound
      */
     public function find(HabitId $id) : ?Habit
     {
         return
             $this->habits->first(fn (Habit $h) => $h->id()->equals($id)) ??
-            throw new HabitNotFoundException($id);
+            throw new HabitNotFound($id);
     }
 
     public function save(Habit $habit) : void

--- a/api/tests/Support/HabitModelFactory.php
+++ b/api/tests/Support/HabitModelFactory.php
@@ -79,7 +79,8 @@ class HabitModelFactory
     ) : Habit {
 
         $attributes = array_merge($overrides, [
-            'lastIncompleted' => CarbonImmutable::now(),
+            'lastCompleted' => null,
+            'streak' => new HabitStreak(),
         ]);
 
         return self::create($attributes);
@@ -91,8 +92,7 @@ class HabitModelFactory
         return new class($count) {
             public function __construct(
                 private int $count
-            ) {
-            }
+            ) {}
 
             /**
              * @param array $overrides

--- a/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
+++ b/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
@@ -3,9 +3,9 @@
 namespace Spec\HabitTracking\Domain;
 
 use Carbon\CarbonImmutable;
-use HabitTracking\Domain\Exceptions\HabitAlreadyCompletedException;
-use HabitTracking\Domain\Exceptions\HabitAlreadyIncompletedException;
-use HabitTracking\Domain\Exceptions\HabitStoppedException;
+use HabitTracking\Domain\Exceptions\HabitAlreadyCompleted;
+use HabitTracking\Domain\Exceptions\HabitAlreadyIncompleted;
+use HabitTracking\Domain\Exceptions\HabitAlreadyStopped;
 use HabitTracking\Domain\Habit;
 use HabitTracking\Domain\HabitFrequency;
 use HabitTracking\Domain\HabitId;
@@ -103,7 +103,7 @@ class HabitSpec extends ObjectBehavior
         ]);
 
         $this->markAsComplete();
-        $this->shouldThrow(HabitAlreadyCompletedException::class)
+        $this->shouldThrow(HabitAlreadyCompleted::class)
             ->during('markAsComplete');
     }
 
@@ -116,7 +116,7 @@ class HabitSpec extends ObjectBehavior
             new HabitFrequency('daily'),
         ]);
 
-        $this->shouldThrow(HabitAlreadyIncompletedException::class)
+        $this->shouldThrow(HabitAlreadyIncompleted::class)
             ->during('markAsIncomplete');
     }
 
@@ -162,7 +162,7 @@ class HabitSpec extends ObjectBehavior
 
         $this->stop();
 
-        $this->shouldThrow(HabitStoppedException::class)
+        $this->shouldThrow(HabitAlreadyStopped::class)
             ->duringStop();
     }
 

--- a/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
+++ b/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
@@ -24,7 +24,6 @@ class HabitSpec extends ObjectBehavior
             $streak = new HabitStreak(),
             $stopped = true,
             $lastCompleted = CarbonImmutable::now(),
-            $lastIncompleted = CarbonImmutable::yesterday(),
         );
 
         $this->shouldBeAnInstanceOf(Habit::class);
@@ -36,7 +35,6 @@ class HabitSpec extends ObjectBehavior
         $this->streak()->shouldBe($streak);
         $this->stopped()->shouldBe($stopped);
         $this->lastCompleted()->shouldBe($lastCompleted);
-        $this->lastIncompleted()->shouldBe($lastIncompleted);
         $this->completed()->shouldBe(true);
     }
 
@@ -57,7 +55,6 @@ class HabitSpec extends ObjectBehavior
         $this->frequency()->shouldBe($frequency);
         $this->streak()->isEmpty()->shouldBe(true);
         $this->lastCompleted()->shouldBe(null);
-        $this->lastIncompleted()->shouldBe(null);
         $this->completed()->shouldBe(false);
         $this->stopped()->shouldBe(false);
     }

--- a/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
+++ b/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
@@ -24,7 +24,7 @@ class HabitSpec extends ObjectBehavior
             $streak = new HabitStreak(),
             $stopped = true,
             $lastCompleted = CarbonImmutable::now(),
-            $lastIncompleted = CarbonImmutable::now()->subDay(),
+            $lastIncompleted = CarbonImmutable::yesterday(),
         );
 
         $this->shouldBeAnInstanceOf(Habit::class);

--- a/api/tests/Unit/Spec/HabitTracking/Domain/HabitStreakSpec.php
+++ b/api/tests/Unit/Spec/HabitTracking/Domain/HabitStreakSpec.php
@@ -44,7 +44,7 @@ class HabitStreakSpec extends ObjectBehavior
     public function it_guards_against_invalid_string_formats()
     {
         $invalidFormats = [
-            '01:02:03', 'Y1M2D3', 'PY1M2D3',
+            '01:02:03', 'Y1M2D3', 'PY1M2D3', 'PP1Y2M3DD',
             'PPYYMMDD', 'P0.1Y5.3M2.3D', '010203',
             '1 Year 2 Months 3 Days',
         ];
@@ -88,22 +88,22 @@ class HabitStreakSpec extends ObjectBehavior
     {
         $this->beConstructedWith(0, 0, 0);
 
-        $this->increment();
+        $incremented = $this->increment();
 
-        $this->years()->shouldBe(0);
-        $this->months()->shouldBe(0);
-        $this->days()->shouldBe(1);
+        $incremented->years()->shouldBe(0);
+        $incremented->months()->shouldBe(0);
+        $incremented->days()->shouldBe(1);
     }
 
     public function it_can_be_decremented_a_day()
     {
         $this->beConstructedWith(0, 0, 2);
 
-        $this->decrement();
+        $decremented = $this->decrement();
 
-        $this->years()->shouldBe(0);
-        $this->months()->shouldBe(0);
-        $this->days()->shouldBe(1);
+        $decremented->years()->shouldBe(0);
+        $decremented->months()->shouldBe(0);
+        $decremented->days()->shouldBe(1);
     }
 
     public function it_cannot_decrement_an_empty_streak()
@@ -118,42 +118,42 @@ class HabitStreakSpec extends ObjectBehavior
     {
         $this->beConstructedWith(0, 0, 29);
 
-        $this->increment();
+        $incremented = $this->increment();
 
-        $this->months()->shouldBe(1);
-        $this->days()->shouldBe(0);
+        $incremented->months()->shouldBe(1);
+        $incremented->days()->shouldBe(0);
 
-        $this->decrement();
+        $decremented = $incremented->decrement();
 
-        $this->months()->shouldBe(0);
-        $this->days()->shouldBe(29);
+        $decremented->months()->shouldBe(0);
+        $decremented->days()->shouldBe(29);
     }
 
     public function it_considers_12_months_to_be_a_year()
     {
         $this->beConstructedWith(0, 11, 29);
 
-        $this->increment();
+        $incremented = $this->increment();
 
-        $this->years()->shouldBe(1);
-        $this->months()->shouldBe(0);
-        $this->days()->shouldBe(0);
+        $incremented->years()->shouldBe(1);
+        $incremented->months()->shouldBe(0);
+        $incremented->days()->shouldBe(0);
 
-        $this->decrement();
+        $decremented = $incremented->decrement();
 
-        $this->years()->shouldBe(0);
-        $this->months()->shouldBe(11);
-        $this->days()->shouldBe(29);
+        $decremented->years()->shouldBe(0);
+        $decremented->months()->shouldBe(11);
+        $decremented->days()->shouldBe(29);
     }
 
     public function it_can_be_serialized()
     {
         $this->beConstructedThrough('fromString', ['P1Y2M3D']);
 
-        $this->shouldImplement(\JsonSerializable::class);
-
-        $this->toString()->shouldBe('P1Y2M3D');
+        $this->shouldImplement(\Stringable::class);
         $this->__toString()->shouldBe('P1Y2M3D');
+
+        $this->shouldImplement(\JsonSerializable::class);
         $this->jsonSerialize()->shouldBe('P1Y2M3D');
     }
 }


### PR DESCRIPTION
Previously, when toggling the completion of a habit. it would through a HabitAlreadyIncompleted exception, although the habit has not been. This was because the completed flag was computed. In this branch, I have simplified the approach and opted to use one timestamp to compute if a habit is complete or not, based on it not being null.