### PR TITLE
Habit Reset

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -31,6 +31,11 @@ This web API is built with [Laravel](https://laravel.com/docs/8.x), consult its 
     php artisan serve
     ```
 
+-   Run the scheduler with the following command:
+    ```bash
+    php artisan schedule:work
+    ```
+
 ### Test Suite
 
 For the test suite, [PHPSpec](http://phpspec.net/en/stable/manual/introduction.html) is used for the unit tests, and [Pest](https://pestphp.com) (which is a wrapper over PHPUnit) is used for the integration tests. Consult their appropriate documentations for more information.

--- a/api/app/Console/Kernel.php
+++ b/api/app/Console/Kernel.php
@@ -25,7 +25,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('habits:reset')->daily();
     }
 
     /**

--- a/api/app/Console/Kernel.php
+++ b/api/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use HabitTracking\Infrastructure\ResetHabitsCommand;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -13,7 +14,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
+        ResetHabitsCommand::class,
     ];
 
     /**

--- a/api/src/HabitTracking/Application/HabitService.php
+++ b/api/src/HabitTracking/Application/HabitService.php
@@ -79,6 +79,15 @@ class HabitService
         return $habit;
     }
 
+    public function resetHabit(string $id) : void
+    {
+        $habit = $this->repository->find(HabitId::fromString($id));
+
+        $habit->reset();
+
+        $this->repository->save($habit);
+    }
+
     public function editHabit(
         string $id,
         string $name,

--- a/api/src/HabitTracking/Domain/Habit.php
+++ b/api/src/HabitTracking/Domain/Habit.php
@@ -18,7 +18,7 @@ class Habit implements \JsonSerializable
         private bool $stopped = false,
         private ? CarbonImmutable $lastCompleted = null,
     ) {
-        $this->streak = $streak ?? new HabitStreak();
+        $this->streak ??= new HabitStreak();
     }
 
     public static function start(
@@ -58,6 +58,11 @@ class Habit implements \JsonSerializable
 
         $this->name = $name;
         $this->frequency = $frequency;
+    }
+
+    public function reset() : void
+    {
+        $this->lastCompleted = null;
     }
 
     public function stop() : void

--- a/api/src/HabitTracking/Infrastructure/ResetHabitsCommand.php
+++ b/api/src/HabitTracking/Infrastructure/ResetHabitsCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace HabitTracking\Infrastructure;
+
+use HabitTracking\Application\HabitService;
+use HabitTracking\Presentation\HabitFinder;
+use Illuminate\Console\Command;
+
+class ResetHabitsCommand extends Command
+{
+    protected $signature = 'habits:reset';
+
+    protected $description = 'Reset all habits.';
+
+    public function handle(
+        HabitService $service,
+        HabitFinder $finder,
+    ) : int {
+
+        $habits = $finder->all();
+
+        $habits->each(function ($habit) use ($service) {
+            $service->resetHabit($habit->id());
+        });
+
+        $this->info('SUCCESS: 10 Habits have been reset.');
+        return Command::SUCCESS;
+    }
+}

--- a/api/tests/Integration/HabitServiceTest.php
+++ b/api/tests/Integration/HabitServiceTest.php
@@ -117,6 +117,17 @@ it("can edit a user's habit", function () {
         ->toBe($habit);
 });
 
+it('can reset a habit', function () {
+    $repository = new CollectionHabitRepository(collect([
+        $habit = HabitModelFactory::completed(),
+    ]));
+
+    (new HabitService($repository))->resetHabit($habit->id());
+
+    expect($repository->find($habit->id()))
+        ->completed()->toBe(false);
+});
+
 it("can stop a user's habit", function () {
     $john = User::factory()->make(['id' => 1]);
     $repository = new CollectionHabitRepository(collect([

--- a/api/tests/Integration/ResetHabitsCommandTest.php
+++ b/api/tests/Integration/ResetHabitsCommandTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use HabitTracking\Presentation\HabitFinder;
+use Tests\Support\HabitFactory;
+
+it('resets all habits', function () {
+    HabitFactory::count(10)->completed();
+
+    $this
+        ->artisan('habits:reset')
+        ->expectsOutput('SUCCESS: 10 Habits have been reset.')
+        ->assertExitCode(0);
+
+    $habits = resolve(HabitFinder::class)->all();
+    expect($habits)->each(function ($habit) {
+        $habit->completed()->toBeFalse();
+    });
+});

--- a/api/tests/Support/HabitFactory.php
+++ b/api/tests/Support/HabitFactory.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Support;
 
+use App\Models\User;
 use HabitTracking\Domain\Contracts\HabitRepository;
 use HabitTracking\Domain\Habit;
 
@@ -11,7 +12,9 @@ class HabitFactory
         array $overrides = []
     ) : Habit {
 
-        $habit = HabitModelFactory::start($overrides);
+        $habit = HabitModelFactory::start(array_merge([
+            'authorId' => User::factory()->create()->id,
+        ], $overrides));
 
         resolve(HabitRepository::class)->save($habit);
 
@@ -22,7 +25,9 @@ class HabitFactory
         array $overrides = []
     ) : Habit {
 
-        $habit = HabitModelFactory::create($overrides);
+        $habit = HabitModelFactory::create(array_merge([
+            'authorId' => User::factory()->create()->id,
+        ], $overrides));
 
         resolve(HabitRepository::class)->save($habit);
 
@@ -33,7 +38,9 @@ class HabitFactory
         array $overrides = []
     ) : Habit {
 
-        $habit = HabitModelFactory::completed($overrides);
+        $habit = HabitModelFactory::completed(array_merge([
+            'authorId' => User::factory()->create()->id,
+        ], $overrides));
 
         resolve(HabitRepository::class)->save($habit);
 
@@ -44,7 +51,9 @@ class HabitFactory
         array $overrides = []
     ) : Habit {
 
-        $habit = HabitModelFactory::incompleted($overrides);
+        $habit = HabitModelFactory::incompleted(array_merge([
+            'authorId' => User::factory()->create()->id,
+        ], $overrides));
 
         resolve(HabitRepository::class)->save($habit);
 
@@ -73,18 +82,27 @@ class HabitFactory
         return new class($count) {
             public function __construct(
                 private int $count
-            ) {
-            }
+            ) {}
 
             /** @return Habit[] */
-            public function start(
-                array $overrides = []
-            ) : array {
-
+            public function start(array $overrides = []) : array
+            {
                 $habits = [];
 
                 for ($i = 0; $i < $this->count; $i++) {
                     $habits[] = HabitFactory::start($overrides);
+                }
+
+                return $habits;
+            }
+
+            /** @return Habit[] */
+            public function completed(array $overrides = []) : array
+            {
+                $habits = [];
+
+                for ($i = 0; $i < $this->count; $i++) {
+                    $habits[] = HabitFactory::completed($overrides);
                 }
 
                 return $habits;

--- a/api/tests/Support/HabitModelFactory.php
+++ b/api/tests/Support/HabitModelFactory.php
@@ -63,7 +63,7 @@ class HabitModelFactory
     }
 
     public static function completed(
-        array $overrides
+        array $overrides = []
     ) : Habit {
 
         $attributes = array_merge($overrides, [
@@ -75,7 +75,7 @@ class HabitModelFactory
     }
 
     public static function incompleted(
-        array $overrides
+        array $overrides = []
     ) : Habit {
 
         $attributes = array_merge($overrides, [

--- a/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
+++ b/api/tests/Unit/Spec/HabitTracking/Domain/HabitSpec.php
@@ -135,6 +135,38 @@ class HabitSpec extends ObjectBehavior
         $this->frequency()->shouldBe($frequency);
     }
 
+    public function it_can_be_reset()
+    {
+        $this->beConstructedThrough('start', [
+            HabitId::generate(),
+            3,
+            'Read a book',
+            new HabitFrequency('daily'),
+        ]);
+
+        $this->reset();
+
+        $this->completed()->shouldBe(false);
+    }
+
+    public function it_maintains_its_streak_when_reset()
+    {
+        $this->beConstructedThrough('start', [
+            HabitId::generate(),
+            3,
+            'Read a book',
+            new HabitFrequency('daily'),
+        ]);
+        $this->markAsComplete();
+        $this->completed()->shouldBe(true);
+        $this->streak()->days()->shouldBe(1);
+
+        $this->reset();
+
+        $this->completed()->shouldBe(false);
+        $this->streak()->days()->shouldBe(1);
+    }
+
     public function it_can_be_stopped()
     {
         $this->beConstructedThrough('start', [


### PR DESCRIPTION
Resetting a habit should occur everyday. In essence it makes the habit in-completed, whilst keeping the streak, in order to allow its author to complete the habit each occurring day.

* Added capability to reset habit in the domain aggregate
* Added reset habit to the habit service
* Added artisan command that resets all habits
* Updated the schedule to run the reset habits command daily